### PR TITLE
Minimum version requirements fix + other minor issues -- #10

### DIFF
--- a/GTA_V_Session_Sniffer.py
+++ b/GTA_V_Session_Sniffer.py
@@ -57,7 +57,6 @@ from Modules.https_utils.unsafe_https import s
 
 if sys.version_info.major <= 3 and sys.version_info.minor < 12:
     print("To use this script, your Python version must be 3.12 or higher.")
-    print("Please note that Python 3.12 is not compatible with Windows versions 7 or lower.")
     sys.exit(0)
 
 logging.basicConfig(
@@ -2582,14 +2581,11 @@ def process_userip_task(player: Player, connection_type: Literal["connected", "d
                 elif player.userip.settings.PROTECTION == "Restart_PC":
                     subprocess.Popen(["shutdown", "/r"])
 
-        voice_notification_setting = player.userip.settings.VOICE_NOTIFICATIONS
-        if voice_notification_setting:
-            if voice_notification_setting == "Male":
+        if player.userip.settings.VOICE_NOTIFICATIONS:
+            if player.userip.settings.VOICE_NOTIFICATIONS == "Male":
                 voice_name = "Liam"
-            elif voice_notification_setting == "Female":
+            elif player.userip.settings.VOICE_NOTIFICATIONS == "Female":
                 voice_name = "Jane"
-            else:
-                raise RuntimeError(f"Unknown value: ${voice_notification_setting = }")
             file_path = Path(f"{TTS_PATH}/{voice_name} ({connection_type}).wav")
 
             if not file_path.exists():
@@ -3976,8 +3972,6 @@ def packet_callback(packet: Packet):
         tshark_restarted_times += 1
         raise PacketCaptureOverflow("Packet capture time exceeded 3 seconds.")
 
-    target_port = -1
-    target_ip = -1
     if Settings.CAPTURE_IP_ADDRESS:
         if packet.ip.src == Settings.CAPTURE_IP_ADDRESS:
             target_ip = packet.ip.dst
@@ -4025,10 +4019,7 @@ def packet_callback(packet: Packet):
             """.removeprefix("\n").removesuffix("\n"))
             terminate_script("EXIT", stdout_crash_text, stdout_crash_text)
 
-    # This ensures that the port and IP have been reassigned since
-    # declaration, or that the script has been terminated.
-    assert target_port != -1 and target_ip != -1
-    if not target_port:
+    if target_port is None:
         stdout_crash_text = textwrap.dedent(f"""
             ERROR:
                 Developer didn't expect this scenario to be possible.

--- a/GTA_V_Session_Sniffer.py
+++ b/GTA_V_Session_Sniffer.py
@@ -1,27 +1,3 @@
-# -----------------------------------------------------
-# 📚 Local Python Libraries (Included with Project) 📚
-# -----------------------------------------------------
-from Modules.oui_lookup.oui_lookup import MacLookup
-from Modules.capture.capture import PacketCapture, Packet
-from Modules.capture.utils import TSharkNotFoundException, get_tshark_path, get_tshark_version, is_npcap_or_winpcap_installed
-from Modules.https_utils.unsafe_https import s
-
-# --------------------------------------------
-# 📦 External/Third-party Python Libraries 📦
-# --------------------------------------------
-import wmi
-import psutil
-import colorama
-import requests
-import geoip2.errors
-import geoip2.database
-from rich.text import Text
-from rich.console import Console
-from rich.traceback import Traceback
-from wmi import _wmi_namespace, _wmi_object
-from prettytable import PrettyTable, TableStyle
-from colorama import Fore, Back, Style
-
 # ------------------------------------------------------
 # 🐍 Standard Python Libraries (Included by Default) 🐍
 # ------------------------------------------------------
@@ -53,9 +29,35 @@ from ipaddress import IPv4Address, AddressValueError
 from dataclasses import dataclass
 
 
-if sys.version_info.major <= 3 and sys.version_info.minor < 9:
-    print("To use this script, your Python version must be 3.9 or higher.")
-    print("Please note that Python 3.9 is not compatible with Windows versions 7 or lower.")
+# --------------------------------------------
+# 📦 External/Third-party Python Libraries 📦
+# --------------------------------------------
+import wmi
+import psutil
+import colorama
+import requests
+import geoip2.errors
+import geoip2.database
+from rich.text import Text
+from rich.console import Console
+from rich.traceback import Traceback
+from wmi import _wmi_namespace, _wmi_object
+from prettytable import PrettyTable, TableStyle
+from colorama import Fore, Back, Style
+
+
+# -----------------------------------------------------
+# 📚 Local Python Libraries (Included with Project) 📚
+# -----------------------------------------------------
+from Modules.oui_lookup.oui_lookup import MacLookup
+from Modules.capture.capture import PacketCapture, Packet
+from Modules.capture.utils import TSharkNotFoundException, get_tshark_path, get_tshark_version, is_npcap_or_winpcap_installed
+from Modules.https_utils.unsafe_https import s
+
+
+if sys.version_info.major <= 3 and sys.version_info.minor < 12:
+    print("To use this script, your Python version must be 3.12 or higher.")
+    print("Please note that Python 3.12 is not compatible with Windows versions 7 or lower.")
     sys.exit(0)
 
 logging.basicConfig(
@@ -419,6 +421,7 @@ class Settings(DefaultSettings):
     def has_setting(cls, setting_name):
         return hasattr(cls, setting_name)
 
+    @staticmethod
     def reconstruct_settings():
         print("\nCorrect reconstruction of \"Settings.ini\" ...")
         text = textwrap.dedent(f"""
@@ -435,6 +438,7 @@ class Settings(DefaultSettings):
             text += f"{setting_name}={setting_value}\n"
         SETTINGS_PATH.write_text(text, encoding="utf-8")
 
+    @staticmethod
     def load_from_settings_file(settings_path: Path):
         matched_settings_count = 0
 
@@ -1122,6 +1126,7 @@ class SessionHost:
     search_player = False
     players_pending_for_disconnection = []
 
+    @staticmethod
     def get_host_player(session_connected: list[Player]):
         connected_players: list[Player] = take(2, sorted(session_connected, key=attrgetter("datetime.last_rejoin")))
 
@@ -1616,7 +1621,7 @@ def show_message_box(title: str, message: str, style: Msgbox.Style) -> int:
     return ctypes.windll.user32.MessageBoxW(0, message, title, style)
 
 def show_error__tshark_not_detected():
-    webbrowser.open(WIRESHARK_REQUIERED_DL)
+    webbrowser.open(WIRESHARK_REQUIRED_DL)
 
     msgbox_title = TITLE
     msgbox_message = textwrap.dedent(f"""
@@ -1970,8 +1975,8 @@ RE_USERIP_INI_PARSER_PATTERN = re.compile(r"^(?![;#])(?P<username>[^=]+)=(?P<ip>
 RE_MODMENU_LOGS_USER_PATTERN = re.compile(r"^user:(?P<username>[\w._-]{1,16}), scid:\d{1,9}, ip:(?P<ip>[\d.]+), timestamp:\d{10}$")
 USERIP_INI_SETTINGS_LIST = ["ENABLED", "COLOR", "NOTIFICATIONS", "VOICE_NOTIFICATIONS", "LOG", "PROTECTION", "PROTECTION_PROCESS_PATH", "PROTECTION_RESTART_PROCESS_PATH", "PROTECTION_SUSPEND_PROCESS_MODE"]
 ANSI_ESCAPE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
-WIRESHARK_REQUIERED_VERSION = "TShark (Wireshark) 4.2.8 (v4.2.8-0-g91fdcf8e29f8)."
-WIRESHARK_REQUIERED_DL = "https://www.wireshark.org/download.html"
+WIRESHARK_REQUIRED_VERSION = "TShark (Wireshark) 4.2.8 (v4.2.8-0-g91fdcf8e29f8)."
+WIRESHARK_REQUIRED_DL = "https://www.wireshark.org/download.html"
 
 cls()
 title(f"Searching for a new update - {TITLE}")
@@ -2162,10 +2167,10 @@ while True:
     else:
         TSHARK_VERSION = get_tshark_version(TSHARK_PATH)
 
-        if TSHARK_VERSION == WIRESHARK_REQUIERED_VERSION:
+        if TSHARK_VERSION == WIRESHARK_REQUIRED_VERSION:
             break
 
-        webbrowser.open(WIRESHARK_REQUIERED_DL)
+        webbrowser.open(WIRESHARK_REQUIRED_DL)
         msgbox_title = TITLE
 
         if TSHARK_VERSION is None:
@@ -2177,7 +2182,7 @@ while True:
                 ERROR: Detected an unsupported \"Tshark (Wireshark)\" version installed on your system.
 
                 Installed version: {TSHARK_VERSION}
-                Requiered version: {WIRESHARK_REQUIERED_VERSION}
+                Required version: {WIRESHARK_REQUIRED_VERSION}
 
                 Opening the \"Wireshark\" project download page for you.
                 You can then download and install it from there and press \"Retry\".
@@ -2577,11 +2582,14 @@ def process_userip_task(player: Player, connection_type: Literal["connected", "d
                 elif player.userip.settings.PROTECTION == "Restart_PC":
                     subprocess.Popen(["shutdown", "/r"])
 
-        if player.userip.settings.VOICE_NOTIFICATIONS:
-            if player.userip.settings.VOICE_NOTIFICATIONS == "Male":
+        voice_notification_setting = player.userip.settings.VOICE_NOTIFICATIONS
+        if voice_notification_setting:
+            if voice_notification_setting == "Male":
                 voice_name = "Liam"
-            elif player.userip.settings.VOICE_NOTIFICATIONS == "Female":
+            elif voice_notification_setting == "Female":
                 voice_name = "Jane"
+            else:
+                raise RuntimeError(f"Unknown value: ${voice_notification_setting = }")
             file_path = Path(f"{TTS_PATH}/{voice_name} ({connection_type}).wav")
 
             if not file_path.exists():
@@ -3249,7 +3257,7 @@ def stdout_render_core():
 
             # Remove deleted files from notified settings conflicts
             # TODO:
-            # I should also warn again on another error, but it'd probably requiere a DICT then.
+            # I should also warn again on another error, but it'd probably require a DICT then.
             # I have things more important to code atm.
             for path in set(UserIP_Databases.notified_settings_corrupted):
                 if not path.exists() or not path.is_file():
@@ -3968,6 +3976,8 @@ def packet_callback(packet: Packet):
         tshark_restarted_times += 1
         raise PacketCaptureOverflow("Packet capture time exceeded 3 seconds.")
 
+    target_port = -1
+    target_ip = -1
     if Settings.CAPTURE_IP_ADDRESS:
         if packet.ip.src == Settings.CAPTURE_IP_ADDRESS:
             target_ip = packet.ip.dst
@@ -4015,6 +4025,9 @@ def packet_callback(packet: Packet):
             """.removeprefix("\n").removesuffix("\n"))
             terminate_script("EXIT", stdout_crash_text, stdout_crash_text)
 
+    # This ensures that the port and IP have been reassigned since
+    # declaration, or that the script has been terminated.
+    assert target_port != -1 and target_ip != -1
     if not target_port:
         stdout_crash_text = textwrap.dedent(f"""
             ERROR:

--- a/GTA_V_Session_Sniffer.py
+++ b/GTA_V_Session_Sniffer.py
@@ -1976,7 +1976,7 @@ RE_MODMENU_LOGS_USER_PATTERN = re.compile(r"^user:(?P<username>[\w._-]{1,16}), s
 USERIP_INI_SETTINGS_LIST = ["ENABLED", "COLOR", "NOTIFICATIONS", "VOICE_NOTIFICATIONS", "LOG", "PROTECTION", "PROTECTION_PROCESS_PATH", "PROTECTION_RESTART_PROCESS_PATH", "PROTECTION_SUSPEND_PROCESS_MODE"]
 ANSI_ESCAPE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
 WIRESHARK_REQUIRED_VERSION = "TShark (Wireshark) 4.2.8 (v4.2.8-0-g91fdcf8e29f8)."
-WIRESHARK_REQUIRED_DL = "https://www.wireshark.org/download.html"
+WIRESHARK_REQUIRED_DL = "https://www.wireshark.org/download/win64/"
 
 cls()
 title(f"Searching for a new update - {TITLE}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 colorama==0.4.6
 geoip2==4.8.1
 prettytable==3.12.0
-psutil==6.0.0
+psutil==6.1.0
 requests==2.32.3
 rich==13.8.1
 urllib3==2.2.3


### PR DESCRIPTION
This pull request addresses the problems outlined in #10:

1. The minimum supported Python version has been bumped from 3.9 to 3.12
2. The imported modules have been rearranged so that they adhere to the generally accepted norm

As well as some other issues:

3. The minimum supported `psutil` version in `requirements.txt` has been bumped from 6.0.0 to 6.1.0, as that's the version required in `third_party_packages` (line [2044](https://github.com/kguzek/GTA-V-Session-Sniffer/blob/a5b9e21356c3afd6b421d31f13035160975bb09a/GTA_V_Session_Sniffer.py#L2044))
4. `@staticmethod` annotations have been added to the methods of the `Settings` class which do not take any arguments, including `self`
5. Assertations have been made that ensure either the appropriate values have been set or that the script has terminated, as well as that the only accepted values for `player.userip.settings.VOICE_NOTIFICATIONS` are `"Male"` and `"Female"`.
6. Several typos of the word `require`/`required` have been corrected
7. Updated the download link of WireShark as the previous one didn't have `v4.2.8` available